### PR TITLE
fix obfuscator randomizing types in typed arguments

### DIFF
--- a/libraries/obfuscator/lib.spwn
+++ b/libraries/obfuscator/lib.spwn
@@ -83,6 +83,7 @@ obfuscate = (inp: @string, use_random_variable_names: @bool = true) {
                         if j == 0 {break}
                         j--
                         
+                        if input[j] == "@" {token_before_equals = ""; break}
                         if !(input[j] in naming+@array(" \t")) {break}
                         if token_before_equals != "" && input[j] in " \t" {break}
 


### PR DESCRIPTION
Fix the bug where obfuscator randomizes name of the type (i.e @bool) when argument is typed and has a default value.